### PR TITLE
Support F-key shortcuts

### DIFF
--- a/normal.py
+++ b/normal.py
@@ -47,15 +47,18 @@ def normal_mode(self, event, char):
     if event.type != X.KeyRelease:
         return 
 
+    handled = False
     if len(pressed) > 1:
         paste_style(self, pressed)
-
-    if len(pressed) == 1:
+        handled = True
+    elif len(pressed) == 1:
         # Get the only element in pressed
         ev = next(iter(pressed))
         handled = handle_single_key(self, ev)
-        if not handled:
-            replay(self)
+        
+    # replay events to Inkscape if we couldn't handle them
+    if not handled:
+        replay(self)
 
     events.clear()
     pressed.clear()


### PR DESCRIPTION
Keypresses of F-keys do not get a string returned from `XK.keysym_to_string` and hence (1) do not get added to `pressed` and (2) do not trigger a `replay` even when they are not handled. This breaks the F-key shortcuts which are a big part of Inkscape.

This PR introduces a change which `replay`s all the `event`s received whenever our application doesn't handle it (previously it only replayed when it receives an `event` representing a `KeyPress` of a key which `keysym_to_string` can interpret as a char)

Resolves #8 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gillescastel/inkscape-shortcut-manager/7)
<!-- Reviewable:end -->
