### PR TITLE
ungrab Mod4+Shift and Mod1+Shift

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,6 +45,8 @@ class Manager():
         # Ungrab window manager shortcuts (Super + ...)
         self.inkscape.ungrab_key(self.string_to_keycode('Super_L'), X.AnyModifier, True)
         self.inkscape.ungrab_key(self.string_to_keycode('Alt_L'), X.AnyModifier, True)
+        self.inkscape.ungrab_key(self.string_to_keycode('Shift_L'), X.Mod4Mask, True)
+        self.inkscape.ungrab_key(self.string_to_keycode('Shift_L'), X.Mod1Mask, True)
         self.inkscape.change_attributes(event_mask=X.KeyReleaseMask | X.KeyPressMask | X.StructureNotifyMask)
 
     def ungrab(self):


### PR DESCRIPTION
Hi!
Many tiling window managers use by default keybindings with both the Super key (Mod4) and the shift key pressed (i.e. `Mod4+Shift+q` to close the focused window). 
Currently, such key combinations are grabbed and therefore can't be used while the script is running.
I was able to solve this by ungrabbing the `Shift_L` key with the modifier `Mod4Mask`  (and also `Mod1Mask` for the Alt key).
This should also resolve #6, since keybindings like `Shift+t` will still work.